### PR TITLE
fix: work around semantic-release/npm plugin prepack issue

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -12,7 +12,7 @@ module.exports = {
         [
             '@semantic-release/npm',
             {
-                tarballDir: 'pack'
+                // Do not set 'tarballDir' without considering this issue: https://github.com/semantic-release/npm/issues/535
             }
         ],
         [


### PR DESCRIPTION
### Proposed Changes

Remove the `tarballDir` setting for the `npm` plugin

### Reason for Changes

There's an issue where the `npm` plugin for `semantic-release` effectively runs `npm prepack` twice when `tarballDir` is set. Worse, if the `tarballDir` is within the package directory and not excluded (by `.npmignore`, for example) then the tarball from the first `prepack` will end up inside the tarball for the second `prepack`, effectively doubling the package size.

See https://github.com/semantic-release/npm/issues/535
