### PR TITLE
Alpha

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -1,3 +1,6 @@
+// semantic-release parses curly-brace template items in plain strings:
+/* eslint-disable no-template-curly-in-string */
+
 module.exports = {
     branches: ['main', {name: 'beta', prerelease: true}],
     plugins: [

--- a/release.config.js
+++ b/release.config.js
@@ -15,7 +15,10 @@ module.exports = {
         [
             '@semantic-release/npm',
             {
-                // Do not set 'tarballDir' without considering this issue: https://github.com/semantic-release/npm/issues/535
+                // Do not set 'tarballDir' to a relative path without considering this issue:
+                // https://github.com/semantic-release/npm/issues/535
+                // If the tarball is within the package directory, it will be included in the second 'prepack' run.
+                tarballDir: '/tmp/semantic-release-${nextRelease.gitHead}/'
             }
         ],
         [
@@ -30,7 +33,7 @@ module.exports = {
         [
             '@semantic-release/github',
             {
-                assets: 'pack/*.tgz'
+                assets: '/tmp/semantic-release-${nextRelease.gitHead}/*.tgz'
             }
         ]
     ]

--- a/release.config.js
+++ b/release.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-    branches: ['main'],
+    branches: ['main', {name: 'beta', prerelease: true}],
     plugins: [
         '@semantic-release/commit-analyzer',
         '@semantic-release/release-notes-generator',


### PR DESCRIPTION
### Proposed Changes

Undo #186 and instead store the npm tarball outside the package directory.

### Reason for Changes

I forgot we need the tarball: we publish it to GitHub.